### PR TITLE
Fix/DEV-2216 Draw behind navigation bar

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/utils/NavigationBarUtils.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/utils/NavigationBarUtils.java
@@ -1,0 +1,27 @@
+package com.reactnativenavigation.utils;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+
+public class NavigationBarUtils {
+  private static int navigationBarHeight = -1;
+  public static void saveNavigationBarHeight(int height) {
+    navigationBarHeight = height;
+  }
+
+  public static int getNavigationBarHeight(Context context) {
+    if (navigationBarHeight > 0) {
+      return navigationBarHeight;
+    }
+    final Resources resources = context.getResources();
+    final int orientation = resources.getConfiguration().orientation;
+    final int resourceId = resources.getIdentifier(orientation == Configuration.ORIENTATION_PORTRAIT ? "navigation_bar_height" : "navigation_bar_height_landscape", "dimen", "android");
+    if (resourceId > 0) {
+      navigationBarHeight = resources.getDimensionPixelSize(resourceId);
+    }
+
+    return navigationBarHeight;
+  }
+
+}

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ChildController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ChildController.java
@@ -6,6 +6,7 @@ import android.view.ViewGroup;
 
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.presentation.Presenter;
+import com.reactnativenavigation.utils.NavigationBarUtils;
 import com.reactnativenavigation.utils.StatusBarUtils;
 import com.reactnativenavigation.viewcontrollers.navigator.Navigator;
 import com.reactnativenavigation.views.Component;
@@ -92,6 +93,7 @@ public abstract class ChildController<T extends ViewGroup> extends ViewControlle
 
     private WindowInsetsCompat onApplyWindowInsets(View view, WindowInsetsCompat insets) {
         StatusBarUtils.saveStatusBarHeight(insets.getSystemWindowInsetTop());
+        NavigationBarUtils.saveNavigationBarHeight(insets.getSystemWindowInsetBottom());
         return applyWindowInsets(findController(view), insets);
     }
 

--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
@@ -7,6 +7,7 @@ import com.reactnativenavigation.interfaces.ScrollEventListener;
 import com.reactnativenavigation.parse.Options;
 import com.reactnativenavigation.presentation.ComponentPresenter;
 import com.reactnativenavigation.presentation.Presenter;
+import com.reactnativenavigation.utils.NavigationBarUtils;
 import com.reactnativenavigation.utils.StatusBarUtils;
 import com.reactnativenavigation.views.ComponentLayout;
 import com.reactnativenavigation.views.ReactComponent;
@@ -109,6 +110,12 @@ public class ComponentViewController extends ChildController<ComponentLayout> {
     @Override
     public void applyBottomInset() {
         if (view != null) presenter.applyBottomInset(view, getBottomInset());
+    }
+
+    @Override
+    public int getBottomInset() {
+        int navigationBarInset = resolveCurrentOptions().statusBar.isHiddenOrDrawBehind() ? 0 : NavigationBarUtils.getNavigationBarHeight(getActivity());
+        return navigationBarInset;
     }
 
     @Override


### PR DESCRIPTION
## Description
**Fix for Android tablets only.** Draw behind the soft navigation bar when viewing a video in fullscreen on Android tablets.

## To Do
- [x] Draw behind the soft navigation bar when a video is playing fullscreen.

## JIRA
[DEV-2216](https://imggaming.atlassian.net/browse/DEV-2216)