### PR TITLE
Fix/DEV-2216 Draw behind navigation bar on phone

### DIFF
--- a/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
+++ b/lib/android/app/src/main/java/com/reactnativenavigation/viewcontrollers/ComponentViewController.java
@@ -118,12 +118,22 @@ public class ComponentViewController extends ChildController<ComponentLayout> {
         return navigationBarInset;
     }
 
+    private int getLeftInset(WindowInsetsCompat insets) {
+        int navigationBarInset = resolveCurrentOptions().statusBar.isHiddenOrDrawBehind() ? 0 : insets.getSystemWindowInsetLeft();
+        return navigationBarInset;
+    }
+
+    private int getRightInset(WindowInsetsCompat insets) {
+        int navigationBarInset = resolveCurrentOptions().statusBar.isHiddenOrDrawBehind() ? 0 : insets.getSystemWindowInsetRight();
+        return navigationBarInset;
+    }
+
     @Override
     protected WindowInsetsCompat applyWindowInsets(ViewController view, WindowInsetsCompat insets) {
         ViewCompat.onApplyWindowInsets(view.getView(), insets.replaceSystemWindowInsets(
-                insets.getSystemWindowInsetLeft(),
+                getLeftInset(insets),
                 insets.getSystemWindowInsetTop(),
-                insets.getSystemWindowInsetRight(),
+                getRightInset(insets),
                 Math.max(insets.getSystemWindowInsetBottom() - getBottomInset(), 0)
         ));
         return insets;


### PR DESCRIPTION
## Description
**Fix for Android phones.** Draw behind the soft navigation bar when viewing a video in fullscreen in any landscape orientation on Android phones.

## To Do
- [x] Draw behind the soft navigation bar when a video is playing fullscreen.

## JIRA
[DEV-2216](https://imggaming.atlassian.net/browse/DEV-2216)